### PR TITLE
implementing Window Scroll Link + ToggleWindowScrollLink

### DIFF
--- a/reaper_csurf_integrator/control_surface_Reaper_actions.h
+++ b/reaper_csurf_integrator/control_surface_Reaper_actions.h
@@ -3465,6 +3465,36 @@ public:
 };
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class ToggleWindowScrollLink : public Action
+    /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+{
+public:
+    virtual const char* GetName() override
+    {
+        return "ToggleWindowScrollLink";
+    }
+
+    virtual void RequestUpdate(ActionContext* context) override
+    {
+        if (context->GetPage()->GetIsWindowScrollLinkActive())
+            context->UpdateWidgetValue(1.0);
+        else
+            context->UpdateWidgetValue(0.0);
+    }
+
+    virtual void Do(ActionContext* context, double value) override
+    {
+        if (value == 0.0)
+            return;
+
+        Page* page = context->GetPage();
+        page->ToggleWindowScrollLink();
+        page->OnTrackListChange();
+        page->ForceUpdateTrackColors();
+    }
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 class TrackEnterFolder : public Action
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 {

--- a/reaper_csurf_integrator/control_surface_integrator.cpp
+++ b/reaper_csurf_integrator/control_surface_integrator.cpp
@@ -1067,6 +1067,7 @@ void CSurfIntegrator::InitActionsDictionary()
     actions_.insert(make_pair("TrackToggleFolderSpill", make_unique<TrackToggleFolderSpill>()));
     actions_.insert(make_pair("TrackFolderParentDisplay", make_unique<TrackFolderParentDisplay>()));
     actions_.insert(make_pair("ToggleFolderView", make_unique<ToggleFolderView>()));
+    actions_.insert(make_pair("ToggleWindowScrollLink", make_unique<ToggleFolderView>()));
     actions_.insert(make_pair("TrackEnterFolder", make_unique<TrackEnterFolder>()));
     actions_.insert(make_pair("ExitCurrentFolder", make_unique<ExitCurrentFolder>()));
     actions_.insert(make_pair("TrackSelect", make_unique<TrackSelect>()));
@@ -3439,7 +3440,20 @@ void TrackNavigationManager::ForceScrollLink()
     auto it = std::find(tracks_.begin(), tracks_.end(), sel);
     if (it != tracks_.end())
     {
-        setTrackOffset((int)std::distance(tracks_.begin(), it));
+        int ammount = 0;
+        if (isWindowsScrollLinkActive_)
+        {
+            int offset = (int)std::distance(tracks_.begin(), it);
+            if (trackNavigators_.size())
+                ammount = (offset / (int)trackNavigators_.size()) * (int)trackNavigators_.size();
+            else
+                ammount = offset;
+        }
+        else
+        {
+            ammount = (int)std::distance(tracks_.begin(), it);
+        }
+        setTrackOffset(ammount);
         page_->OnTrackSelectionBySurface(sel);
     }
     else

--- a/reaper_csurf_integrator/control_surface_integrator.h
+++ b/reaper_csurf_integrator/control_surface_integrator.h
@@ -3036,6 +3036,7 @@ protected:
     vector<MediaTrack *> selectedTracks_;
 
     bool isFolderViewActive_ = true;
+    bool isWindowsScrollLinkActive_ = true;
     int currentFolderTrackID_ = 0; // 0 is for root folder
     MediaTrack* parentOfCurrentFolderTrack_ = nullptr;
 
@@ -3064,7 +3065,15 @@ protected:
             return;
         }
 
-        int maxOffset = static_cast<int>(tracks_.size() - trackNavigators_.size());
+        if (trackNavigators_.size() == 0)
+            return;
+
+        int maxOffset = 0;
+        if (isWindowsScrollLinkActive_)
+            maxOffset = static_cast<int>(((tracks_.size() - 1) / trackNavigators_.size()) * trackNavigators_.size());
+        else
+            maxOffset = static_cast<int>(tracks_.size() - 1);
+
         if (maxOffset < 0)
             maxOffset = 0;
 
@@ -3134,6 +3143,17 @@ public:
     {
         return isFolderViewActive_;
     }
+
+    void ToggleWindowScrollLink()
+    {
+        isWindowsScrollLinkActive_ = !isWindowsScrollLinkActive_;
+    }
+
+    bool GetIsWindowScrollLinkActive() const
+    {
+        return isWindowsScrollLinkActive_;
+    }
+
 
     void VCAModeActivated()
     {
@@ -3980,6 +4000,8 @@ public:
     Navigator * GetFocusedFXNavigator() { return trackNavigationManager_->GetFocusedFXNavigator(); }
     void ToggleFolderView() { trackNavigationManager_->ToggleFolderView(); }
     bool GetIsFolderViewActive() { return trackNavigationManager_->GetIsFolderViewActive(); }
+    void ToggleWindowScrollLink() { trackNavigationManager_->ToggleWindowScrollLink(); }
+    bool GetIsWindowScrollLinkActive() { return trackNavigationManager_->GetIsWindowScrollLinkActive(); }
     MediaTrack* SetCurrentFolder(MediaTrack* track) { return trackNavigationManager_->SetCurrentFolder(track); }
     MediaTrack* ExitCurrentFolder() { return trackNavigationManager_->ExitCurrentFolder(); }
     bool IsAtRootFolderLevel() { return trackNavigationManager_->IsAtRootFolderLevel(); }


### PR DESCRIPTION
This feature implements window-sized scrolling. For instance, with 11 tracks and a Surface-Controller capable of handling  4 tracks:

Starting at offset 1, tracks 1-4 are visible, followed by 5-8, consistent with previous behavior.
However, the next click displays 9-11, and subsequent bank+ clicks will still show 9-11 without further change. Clicking bank- at this point will move the view back to tracks 5-8.
When folder view is enabled, selecting any on-screen track adjusts the window to reflect relevant tracks. Using the same example of 11 tracks and a 4-track display:

Clicking track 7 will instantly show the 5-8 window on the device, encompassing the selected track.


